### PR TITLE
feat(i18n): add Finnish locale seed translations

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -421,6 +421,7 @@ BABEL_DEFAULT_FOLDER = "superset/translations"
 LANGUAGES = {
     "en": {"flag": "us", "name": "English"},
     "es": {"flag": "es", "name": "Spanish"},
+    "fi": {"flag": "fi", "name": "Finnish"},
     "it": {"flag": "it", "name": "Italian"},
     "fr": {"flag": "fr", "name": "French"},
     "zh": {"flag": "cn", "name": "Chinese"},

--- a/superset/translations/fi/LC_MESSAGES/messages.po
+++ b/superset/translations/fi/LC_MESSAGES/messages.po
@@ -1,7 +1,18 @@
-# Finnish translations for Apache Superset.
-# Copyright (C) 2026 The Apache Software Foundation
-# This file is distributed under the same license as the Apache Superset project.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 msgid ""
 msgstr ""
 "Project-Id-Version: Apache Superset 6.1.0rc1\n"

--- a/superset/translations/fi/LC_MESSAGES/messages.po
+++ b/superset/translations/fi/LC_MESSAGES/messages.po
@@ -1,0 +1,75 @@
+# Finnish translations for Apache Superset.
+# Copyright (C) 2026 The Apache Software Foundation
+# This file is distributed under the same license as the Apache Superset project.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Apache Superset 6.1.0rc1\n"
+"Report-Msgid-Bugs-To: dev@superset.apache.org\n"
+"POT-Creation-Date: 2026-01-01 00:00+0000\n"
+"PO-Revision-Date: 2026-03-16 00:00+0000\n"
+"Last-Translator: Apache Superset Contributors\n"
+"Language-Team: Finnish\n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Generated-By: manual\n"
+
+msgid "Add"
+msgstr "Lisää"
+
+msgid "Cancel"
+msgstr "Peruuta"
+
+msgid "Close"
+msgstr "Sulje"
+
+msgid "Dashboard"
+msgstr "Koontinäyttö"
+
+msgid "Dashboards"
+msgstr "Koontinäytöt"
+
+msgid "Delete"
+msgstr "Poista"
+
+msgid "Edit"
+msgstr "Muokkaa"
+
+msgid "No"
+msgstr "Ei"
+
+msgid "Ok"
+msgstr "OK"
+
+msgid "Run"
+msgstr "Suorita"
+
+msgid "Save"
+msgstr "Tallenna"
+
+msgid "Settings"
+msgstr "Asetukset"
+
+msgid "Slice"
+msgstr "Viipale"
+
+msgid "Slices"
+msgstr "Viipaleet"
+
+msgid "SQL Lab"
+msgstr "SQL-laboratorio"
+
+msgid "Unknown"
+msgstr "Tuntematon"
+
+msgid "User"
+msgstr "Käyttäjä"
+
+msgid "Users"
+msgstr "Käyttäjät"
+
+msgid "Yes"
+msgstr "Kyllä"


### PR DESCRIPTION
### Motivation
- Provide an initial Finnish (fi) language pack so Finnish can be selected as a UI locale and used in Superset releases (seed translations for 6.1.0rc1). 
- Register the locale in the application `LANGUAGES` mapping so it appears in the language selector when i18n is enabled.

### Description
- Added `superset/translations/fi/LC_MESSAGES/messages.po` with header metadata (Project-Id-Version: Apache Superset 6.1.0rc1) and a seed set of common UI string translations (Save/Cancel/Settings/Dashboard/SQL Lab, etc.).
- Registered `"fi": {"flag": "fi", "name": "Finnish"}` in `LANGUAGES` in `superset/config.py` to make the locale discoverable.
- Committed the new translation file and config change under the commit message `feat(i18n): add Finnish locale seed translations`.

### Testing
- Ran `python3 -m py_compile superset/config.py`, which succeeded to validate the config file compiles. 
- Attempted `pre-commit run --all-files` but the `pre-commit` command was not available in the environment, so hooks were not executed. 
- Attempted to install `pre-commit` via `python3 -m pip install pre-commit` but installation failed due to a network/proxy error (403), so full pre-commit validation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b825dbad188331b0cdb1316c7bfea3)